### PR TITLE
Allow to set a maximum retry count (maxRetries) for HttpExec

### DIFF
--- a/exec/context.go
+++ b/exec/context.go
@@ -44,6 +44,8 @@ type Context interface {
 
 	// CorrelationId is the id which should be transferred in the service chain
 	CorrelationId() string
+	SetRetries(retries uint)
+	Retries() uint
 }
 
 type ContextImpl struct {
@@ -51,6 +53,7 @@ type ContextImpl struct {
 	env           map[string]string
 	testNumber    int
 	correlationId string
+	retries       uint
 }
 
 // NewDefaultContext creates a new context without data
@@ -60,6 +63,7 @@ func NewDefaultContext() *ContextImpl {
 		test:          make(map[string]string),
 		testNumber:    0,
 		correlationId: "",
+		retries:       0,
 	}
 }
 
@@ -71,6 +75,7 @@ func NewContext(env map[string]string) *ContextImpl {
 		test:          make(map[string]string),
 		testNumber:    0,
 		correlationId: "",
+		retries:       0,
 	}
 	if cntx.env == nil {
 		cntx.env = make(map[string]string)
@@ -152,4 +157,12 @@ func (cntx *ContextImpl) Populate(n int, createTestDataClosure func(testNumber i
 		close(resultChannel)
 	}()
 	return resultChannel
+}
+
+func (cntx *ContextImpl) Retries() uint {
+	return cntx.retries
+}
+
+func (cntx *ContextImpl) SetRetries(retries uint) {
+	cntx.retries = retries
 }

--- a/exec/execution.go
+++ b/exec/execution.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -11,6 +12,7 @@ type Execution struct {
 	jobTitle string
 	err      error
 	context  Context
+	retries  uint
 }
 
 func StartExecution(jobTitle string, context *Context) *Execution {
@@ -35,9 +37,15 @@ func (execution *Execution) Error() error {
 }
 
 func (execution *Execution) String() string {
-	if execution.err == nil {
-		return fmt.Sprintf("%v %v %v", execution.Duration(), execution.jobTitle, execution.context.CorrelationId())
-	} else {
-		return fmt.Sprintf("%v %v: %v %v", execution.Duration(), execution.jobTitle, execution.err, execution.context.CorrelationId())
+	msgParts := []string{}
+	msgParts = append(msgParts, execution.Duration().String(), fmt.Sprintf("%v:", execution.jobTitle))
+	if execution.err != nil {
+		msgParts = append(msgParts, fmt.Sprintf("%v", execution.err))
 	}
+	if execution.context.Retries() > 0 {
+		msgParts = append(msgParts, fmt.Sprintf("(%v retries)", execution.context.Retries()))
+	}
+	msgParts = append(msgParts, execution.context.CorrelationId())
+
+	return strings.Join(msgParts[:], " ")
 }

--- a/exec/func.go
+++ b/exec/func.go
@@ -1,9 +1,8 @@
 package exec
 
 type FuncExec struct {
-	f       func() error
-	name    string
-	retries uint
+	f    func() error
+	name string
 }
 
 func F(name string, f func() error) *FuncExec {
@@ -19,7 +18,4 @@ func (s *FuncExec) String(cntx Context) string {
 
 func (s *FuncExec) Exec(cntx Context) error {
 	return s.f()
-}
-func (s *FuncExec) Retries() uint {
-	return s.retries
 }

--- a/exec/func.go
+++ b/exec/func.go
@@ -1,8 +1,9 @@
 package exec
 
 type FuncExec struct {
-	f    func() error
-	name string
+	f       func() error
+	name    string
+	retries uint
 }
 
 func F(name string, f func() error) *FuncExec {
@@ -18,4 +19,7 @@ func (s *FuncExec) String(cntx Context) string {
 
 func (s *FuncExec) Exec(cntx Context) error {
 	return s.f()
+}
+func (s *FuncExec) Retries() uint {
+	return s.retries
 }

--- a/exec/http_test.go
+++ b/exec/http_test.go
@@ -166,8 +166,8 @@ func Test_Retryable_Http_ConditionMet2(t *testing.T) {
 	a.EqualValues(uint(2), cntx.retries) // two retries == three requests made
 }
 
-// Test for exceeding maxRetries
-func Test_Retryable_Http_RetriesExceeded(t *testing.T) {
+// Test for hitting maxRetries
+func Test_Retryable_Http_RetriesHit(t *testing.T) {
 	setTimeUnit(time.Millisecond)
 	defer setTimeUnit(time.Second)
 	a := assert.New(t)

--- a/exec/http_test.go
+++ b/exec/http_test.go
@@ -1,11 +1,13 @@
 package exec
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var html = `<html>
@@ -104,4 +106,78 @@ func Test_Http_Post(t *testing.T) {
 
 	a.Error(Post("h :// invalid", "application/foo", "demo data").
 		Exec(cntx))
+}
+
+// Return a server that gives several responses depending on the amount of
+// retries made
+func pollingServer() *httptest.Server {
+
+	responseProvider := func() func(resp http.ResponseWriter, req *http.Request) {
+		cnt := 0
+		return func(resp http.ResponseWriter, req *http.Request) {
+			// first resonses is NOT_FOUND
+			if cnt < 1 {
+				resp.WriteHeader(404)
+				resp.Write([]byte(html))
+			} else if cnt < 2 {
+				// second resonse is any other status
+				resp.WriteHeader(500)
+				resp.Write([]byte("expected value 1"))
+			} else {
+				// second resonse is OK
+				resp.WriteHeader(200)
+				resp.Write([]byte("expected value 2"))
+			}
+			cnt++
+		}
+	}
+	server := httptest.NewServer(http.HandlerFunc(responseProvider()))
+	return server
+}
+
+// Test that retries are stopped when a given condition is met
+func Test_Retryable_Http_ConditionMet(t *testing.T) {
+	setTimeUnit(time.Millisecond)
+	defer setTimeUnit(time.Second)
+	a := assert.New(t)
+	cntx := &ContextImpl{}
+
+	server := pollingServer()
+	defer server.Close()
+
+	getExec := Get(server.URL).MaxRetries(4)
+	a.NoError(getExec.HasCode(500).Exec(cntx))
+	a.EqualValues(uint(1), cntx.retries) // one retry == two requests made
+}
+
+// Test that retries are stopped when a given condition is met
+func Test_Retryable_Http_ConditionMet2(t *testing.T) {
+	setTimeUnit(time.Millisecond)
+	defer setTimeUnit(time.Second)
+	a := assert.New(t)
+	cntx := &ContextImpl{}
+
+	server := pollingServer()
+	defer server.Close()
+
+	getExec := Get(server.URL).MaxRetries(4)
+
+	a.NoError(getExec.Contains("expected value 2").Exec(cntx))
+	a.EqualValues(uint(2), cntx.retries) // two retries == three requests made
+}
+
+// Test for exceeding maxRetries
+func Test_Retryable_Http_RetriesExceeded(t *testing.T) {
+	setTimeUnit(time.Millisecond)
+	defer setTimeUnit(time.Second)
+	a := assert.New(t)
+	cntx := &ContextImpl{}
+
+	server := pollingServer()
+	defer server.Close()
+
+	getExec := Get(server.URL).MaxRetries(1)
+
+	a.Error(getExec.Contains("expected value 2").Exec(cntx))
+	a.EqualValues(uint(1), cntx.retries) // one retry == two requests made
 }


### PR DESCRIPTION
This changeset implements retrying of http requests until the response matches the expectations or the maximum retry count is hit.
