### PR TITLE
Allow to retry HTTP requests.

### DIFF
--- a/exec/context.go
+++ b/exec/context.go
@@ -44,6 +44,8 @@ type Context interface {
 
 	// CorrelationId is the id which should be transferred in the service chain
 	CorrelationId() string
+	SetRetries(retries uint)
+	Retries() uint
 }
 
 type ContextImpl struct {
@@ -51,6 +53,7 @@ type ContextImpl struct {
 	env           map[string]string
 	testNumber    int
 	correlationId string
+	retries       uint
 }
 
 // NewDefaultContext creates a new context without data
@@ -60,6 +63,7 @@ func NewDefaultContext() *ContextImpl {
 		test:          make(map[string]string),
 		testNumber:    0,
 		correlationId: "",
+		retries:       0,
 	}
 }
 
@@ -71,6 +75,7 @@ func NewContext(env map[string]string) *ContextImpl {
 		test:          make(map[string]string),
 		testNumber:    0,
 		correlationId: "",
+		retries:       0,
 	}
 	if cntx.env == nil {
 		cntx.env = make(map[string]string)
@@ -152,4 +157,12 @@ func (cntx *ContextImpl) Populate(n int, createTestDataClosure func(testNumber i
 		close(resultChannel)
 	}()
 	return resultChannel
+}
+
+func (cntx *ContextImpl) Retries() uint {
+	return cntx.retries
+}
+
+func (cntx *ContextImpl) SetRetries(retries uint) {
+	cntx.retries = retries
 }

--- a/exec/execution.go
+++ b/exec/execution.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -11,6 +12,7 @@ type Execution struct {
 	jobTitle string
 	err      error
 	context  Context
+	retries  uint
 }
 
 func StartExecution(jobTitle string, context *Context) *Execution {
@@ -35,9 +37,15 @@ func (execution *Execution) Error() error {
 }
 
 func (execution *Execution) String() string {
-	if execution.err == nil {
-		return fmt.Sprintf("%v %v %v", execution.Duration(), execution.jobTitle, execution.context.CorrelationId())
-	} else {
-		return fmt.Sprintf("%v %v: %v %v", execution.Duration(), execution.jobTitle, execution.err, execution.context.CorrelationId())
+	msgParts := []string{}
+	msgParts = append(msgParts, execution.Duration().String(), fmt.Sprintf("%v:", execution.jobTitle))
+	if execution.err != nil {
+		msgParts = append(msgParts, fmt.Sprintf("%v", execution.err))
 	}
+	if execution.context.Retries() > 0 {
+		msgParts = append(msgParts, fmt.Sprintf("(%v retries)", execution.context.Retries()))
+	}
+	msgParts = append(msgParts, execution.context.CorrelationId())
+
+	return strings.Join(msgParts[:], " ")
 }


### PR DESCRIPTION
Retries will be performed until a given threshold (maxRetries) is hit or
a given condition is met.

Rationale: To implement polling scenarios.
